### PR TITLE
add database schema for notifications and daily quests

### DIFF
--- a/expence_app/sql/004_notifications.sql
+++ b/expence_app/sql/004_notifications.sql
@@ -1,0 +1,36 @@
+-- Create notifications table
+CREATE TABLE IF NOT EXISTS notifications (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+  type TEXT NOT NULL CHECK (type IN ('quest_complete', 'level_up', 'achievement', 'friend_request', 'daily_reminder', 'system_alert')),
+  title TEXT NOT NULL,
+  message TEXT,
+  related_id UUID,
+  is_read BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  read_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications(user_id);
+CREATE INDEX IF NOT EXISTS idx_notifications_is_read ON notifications(is_read);
+CREATE INDEX IF NOT EXISTS idx_notifications_created_at ON notifications(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_notifications_user_unread ON notifications(user_id, is_read) WHERE is_read = FALSE;
+
+-- Row Level Security Policies for notifications
+ALTER TABLE notifications ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see their own notifications
+CREATE POLICY "Users can view their own notifications"
+  ON notifications FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Users can only update their own notifications (mark as read)
+CREATE POLICY "Users can update their own notifications"
+  ON notifications FOR UPDATE
+  USING (auth.uid() = user_id);
+
+-- System can insert notifications for any user
+CREATE POLICY "System can insert notifications"
+  ON notifications FOR INSERT
+  WITH CHECK (true);

--- a/expence_app/sql/005_daily_quest_completions.sql
+++ b/expence_app/sql/005_daily_quest_completions.sql
@@ -1,0 +1,73 @@
+-- Add is_daily field to quests table
+ALTER TABLE quests
+ADD COLUMN IF NOT EXISTS is_daily BOOLEAN DEFAULT FALSE;
+
+-- Create daily_quest_completions table
+CREATE TABLE IF NOT EXISTS daily_quest_completions (
+  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+  quest_id UUID REFERENCES quests(id) ON DELETE CASCADE NOT NULL,
+  completed_date DATE NOT NULL,
+  completed_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  exp_earned INTEGER DEFAULT 0,
+  streak_count INTEGER DEFAULT 1,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  UNIQUE(user_id, quest_id, completed_date)
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_daily_completions_user_id ON daily_quest_completions(user_id);
+CREATE INDEX IF NOT EXISTS idx_daily_completions_quest_id ON daily_quest_completions(quest_id);
+CREATE INDEX IF NOT EXISTS idx_daily_completions_date ON daily_quest_completions(completed_date DESC);
+CREATE INDEX IF NOT EXISTS idx_daily_completions_user_quest ON daily_quest_completions(user_id, quest_id);
+CREATE INDEX IF NOT EXISTS idx_quests_is_daily ON quests(is_daily) WHERE is_daily = TRUE;
+
+-- Row Level Security Policies
+ALTER TABLE daily_quest_completions ENABLE ROW LEVEL SECURITY;
+
+-- Users can only see their own daily completions
+CREATE POLICY "Users can view their own daily completions"
+  ON daily_quest_completions FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- Users can insert their own daily completions
+CREATE POLICY "Users can insert their own daily completions"
+  ON daily_quest_completions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Users cannot update or delete daily completions (immutable record)
+CREATE POLICY "Users cannot update daily completions"
+  ON daily_quest_completions FOR UPDATE
+  USING (false);
+
+CREATE POLICY "Users cannot delete daily completions"
+  ON daily_quest_completions FOR DELETE
+  USING (false);
+
+-- Function to calculate streak for a user's daily quest
+CREATE OR REPLACE FUNCTION get_daily_quest_streak(p_user_id UUID, p_quest_id UUID)
+RETURNS INTEGER AS $$
+DECLARE
+  current_streak INTEGER := 0;
+  check_date DATE := CURRENT_DATE;
+BEGIN
+  -- Loop backwards from today to find consecutive days
+  LOOP
+    -- Check if there's a completion for this date
+    IF EXISTS (
+      SELECT 1 FROM daily_quest_completions
+      WHERE user_id = p_user_id
+        AND quest_id = p_quest_id
+        AND completed_date = check_date
+    ) THEN
+      current_streak := current_streak + 1;
+      check_date := check_date - INTERVAL '1 day';
+    ELSE
+      -- Streak broken
+      EXIT;
+    END IF;
+  END LOOP;
+
+  RETURN current_streak;
+END;
+$$ LANGUAGE plpgsql STABLE;

--- a/expence_app/src/lib/supabase.ts
+++ b/expence_app/src/lib/supabase.ts
@@ -120,9 +120,77 @@ export interface Database {
           due_date: string | null
           completion_date: string | null
           ai_generated: boolean
+          is_daily: boolean
           quest_data: any | null
           created_at: string
           updated_at: string
+        }
+      }
+      notifications: {
+        Row: {
+          id: string
+          user_id: string
+          type: 'quest_complete' | 'level_up' | 'achievement' | 'friend_request' | 'daily_reminder' | 'system_alert'
+          title: string
+          message: string | null
+          related_id: string | null
+          is_read: boolean
+          created_at: string
+          read_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          type: 'quest_complete' | 'level_up' | 'achievement' | 'friend_request' | 'daily_reminder' | 'system_alert'
+          title: string
+          message?: string | null
+          related_id?: string | null
+          is_read?: boolean
+          created_at?: string
+          read_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          type?: 'quest_complete' | 'level_up' | 'achievement' | 'friend_request' | 'daily_reminder' | 'system_alert'
+          title?: string
+          message?: string | null
+          related_id?: string | null
+          is_read?: boolean
+          created_at?: string
+          read_at?: string | null
+        }
+      }
+      daily_quest_completions: {
+        Row: {
+          id: string
+          user_id: string
+          quest_id: string
+          completed_date: string
+          completed_at: string
+          exp_earned: number
+          streak_count: number
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          quest_id: string
+          completed_date: string
+          completed_at?: string
+          exp_earned?: number
+          streak_count?: number
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          quest_id?: string
+          completed_date?: string
+          completed_at?: string
+          exp_earned?: number
+          streak_count?: number
+          created_at?: string
         }
       }
     }
@@ -132,3 +200,5 @@ export interface Database {
 export type User = Database['public']['Tables']['users']['Row']
 export type FinancialGoal = Database['public']['Tables']['financial_goals']['Row']
 export type Quest = Database['public']['Tables']['quests']['Row']
+export type Notification = Database['public']['Tables']['notifications']['Row']
+export type DailyQuestCompletion = Database['public']['Tables']['daily_quest_completions']['Row']

--- a/expence_app/src/types/dailyQuest.ts
+++ b/expence_app/src/types/dailyQuest.ts
@@ -1,0 +1,35 @@
+export interface DailyQuestCompletion {
+  id: string
+  user_id: string
+  quest_id: string
+  completed_date: string
+  completed_at: string
+  exp_earned: number
+  streak_count: number
+  created_at: string
+}
+
+export interface DailyQuestStatus {
+  quest_id: string
+  can_check_in_today: boolean
+  last_check_in_date: string | null
+  current_streak: number
+  total_completions: number
+  checked_in_today: boolean
+}
+
+export interface CheckInResult {
+  success: boolean
+  completion: DailyQuestCompletion | null
+  streak: number
+  exp_earned: number
+  message: string
+}
+
+export interface DailyQuestWithStatus {
+  quest_id: string
+  title: string
+  description: string
+  exp_reward: number
+  status: DailyQuestStatus
+}

--- a/expence_app/src/types/notification.ts
+++ b/expence_app/src/types/notification.ts
@@ -1,0 +1,39 @@
+export enum NotificationType {
+  QUEST_COMPLETE = 'quest_complete',
+  LEVEL_UP = 'level_up',
+  ACHIEVEMENT = 'achievement',
+  FRIEND_REQUEST = 'friend_request',
+  DAILY_REMINDER = 'daily_reminder',
+  SYSTEM_ALERT = 'system_alert'
+}
+
+export interface Notification {
+  id: string
+  user_id: string
+  type: NotificationType
+  title: string
+  message: string | null
+  related_id: string | null
+  is_read: boolean
+  created_at: string
+  read_at: string | null
+}
+
+export interface CreateNotificationInput {
+  user_id: string
+  type: NotificationType
+  title: string
+  message?: string
+  related_id?: string
+}
+
+export interface NotificationWithRelated extends Notification {
+  relatedQuest?: {
+    id: string
+    title: string
+  }
+  relatedUser?: {
+    id: string
+    username: string
+  }
+}


### PR DESCRIPTION
created sql migrations and typescript types for notification system and daily quest check-ins
- notifications table with user permissions
- daily_quest_completions table to track check-ins
- is_daily flag on quests table
- streak calculation function
- typescript types for everything

just db setup for upcoming features